### PR TITLE
駅すぱあとAPIレスポンスのパース処理を修正しました。

### DIFF
--- a/node-red/ekispert-flow-get-station.json
+++ b/node-red/ekispert-flow-get-station.json
@@ -73,7 +73,7 @@
         "type": "function",
         "z": "776a234b.b478cc",
         "name": "set station",
-        "func": "context.global.stationName = msg.payload.ResultSet.Point.Station.Name;\ncontext.global.stationCode = msg.payload.ResultSet.Point.Station.code;\n\nreturn {\n  payload: {\n    stationName: context.global.stationName,\n    stationCode: context.global.stationCode\n  }\n};",
+        "func": "var points = msg.payload.ResultSet.Point;\nif(!Array.isArray(points))\n{\n  points = [points];}\n\ncontext.global.stationName = points[0].Station.Name;\ncontext.global.stationCode = points[0].Station.code;\n\nreturn {\n  payload: {\n    stationName: context.global.stationName,\n    stationCode: context.global.stationCode\n  }\n};",
         "outputs": 1,
         "noerr": 0,
         "x": 850,


### PR DESCRIPTION
駅すぱあとのAPIは、要素が複数存在する場合とそうでない場合で
構造が変化してしまいます（ハッシュor配列）

リクエスト時に`limit=1`で要素を一つに絞っていて
ユーザがリクエストをいじってレスポンスが配列でかえってきても
パースできるように処理を追加しました。